### PR TITLE
Restore full API and add healthcheck

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,6 +23,11 @@ app = FastAPI(
     }]
 )
 
+# --- Healthcheck ---
+@app.get("/")
+async def healthcheck():
+    return {"status": "ok"}
+
 # === ORACLE SCHEMAS ===
 class Metadata(BaseModel):
     patch: str


### PR DESCRIPTION
## Summary
- revert prior simplification of `main.py`
- add a `/` healthcheck endpoint

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py`
- `python main.py` (started and stopped uvicorn)

------
https://chatgpt.com/codex/tasks/task_b_687d7183a2bc832896b3dc85eda1168c